### PR TITLE
Add CMake build scripts derived from LuaDist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,84 @@
+# Copyright (C) 2007-2012 LuaDist.
+# Created by Peter Kapec
+# Redistribution and use of this file is allowed according to the terms of the MIT license.
+# Please note that the package source code is licensed under its own license.
+
+project ( rxspencer C )
+cmake_minimum_required ( VERSION 3.0 )
+include ( cmake/mkh.cmake )
+
+# Patch regerror.c to avoid conflict in MSVC
+if ( MSVC )
+  file ( READ regerror.c REGERROR )
+  string ( REGEX MATCH errcode REGERROR_UNPATCHED "${REGERROR}" )
+  if ( REGERROR_UNPATCHED )
+    string ( REPLACE errcode errorcode REGERROR "${REGERROR}" )
+    file ( WRITE regerror.c "${REGERROR}" )
+  endif ( )
+endif ( )
+
+mkh ( regcomp.c ${CMAKE_BINARY_DIR}/regcomp.ih "" )
+mkh ( engine.c ${CMAKE_BINARY_DIR}/engine.ih "" )
+mkh ( regerror.c ${CMAKE_BINARY_DIR}/regerror.ih "" )
+mkh ( debug.c ${CMAKE_BINARY_DIR}/debug.ih "" )
+mkh ( main.c ${CMAKE_BINARY_DIR}/main.ih "" )
+mkh ( "regex2.h;regcomp.c;regerror.c;regexec.c;regfree.c" ${CMAKE_BINARY_DIR}/regex.h "_REGEX_H_" )
+
+# Patch regex.h for off_t on msvc
+if ( MSVC )
+  file ( READ ${CMAKE_BINARY_DIR}/regex.h REGEXH )
+  string ( REGEX MATCH "sys/types" REGEXH_PATCHED "${REGEXH}" )
+  if ( NOT REGEXH_PATCHED )
+    string ( REPLACE "typedef off_t" "#include <sys/types.h>\ntypedef off_t" REGEXH
+      "${REGEXH}" )
+    file ( WRITE "${CMAKE_BINARY_DIR}/regex.h" "${REGEXH}" )
+    set ( REGEX_H ${CMAKE_BINARY_DIR}/regex.h )
+  endif ( )
+endif ( )
+
+# rxspencer library
+set ( CMAKE_INCLUDE_CURRENT_DIR 1 )
+set ( RXSPENCER_SRCS regcomp.c regerror.c regexec.c regfree.c )
+set ( RXSPENCER_INCLUDE_DIR include/rxspencer )
+set ( RXSPENCER_BIN_DIR bin )
+set ( RXSPENCER_LIB_DIR lib )
+set ( RXSPENCER_DATA_DIR share/rxspencer )
+
+if ( MSVC )
+  set ( DEF_FILE librxspencer.def )
+endif ( )
+
+add_library ( rxspencer ${RXSPENCER_SRCS} ${DEF_FILE} )
+set_target_properties ( rxspencer PROPERTIES PUBLIC_HEADER ${CMAKE_BINARY_DIR}/regex.h )
+target_include_directories ( rxspencer PUBLIC
+  $<INSTALL_INTERFACE:${RXSPENCER_INCLUDE_DIR}>
+  $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}> )
+
+install ( TARGETS rxspencer
+  EXPORT RXSpencerTargets
+  RUNTIME DESTINATION ${RXSPENCER_BIN_DIR}
+  LIBRARY DESTINATION ${RXSPENCER_LIB_DIR}
+  ARCHIVE DESTINATION ${RXSPENCER_LIB_DIR}
+  PUBLIC_HEADER DESTINATION ${RXSPENCER_INCLUDE_DIR} )
+
+# Install docs
+set ( RXSPENCER_DATA_FILES "COPYRIGHT;README;WHATSNEW" )
+install ( FILES ${RXSPENCER_DATA_FILES} DESTINATION ${RXSPENCER_DATA_DIR} )
+
+# generate cmake configuration file
+include ( CMakePackageConfigHelpers )
+if ( NOT DEFINED CMAKE_CONFIG_DEST )
+  set ( CMAKE_CONFIG_DEST lib/cmake/rxspencer )
+endif()
+configure_package_config_file (
+  RXSpencerConfig.cmake.in
+  ${CMAKE_BINARY_DIR}/RXSpencerConfig.cmake
+  INSTALL_DESTINATION ${CMAKE_CONFIG_DEST}
+  PATH_VARS RXSPENCER_INCLUDE_DIR CMAKE_CONFIG_DEST )
+
+install ( EXPORT RXSpencerTargets DESTINATION ${CMAKE_CONFIG_DEST} )
+
+# install the configuration file
+install ( FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/RXSpencerConfig.cmake
+  DESTINATION ${CMAKE_CONFIG_DEST} )

--- a/RXSpencerConfig.cmake.in
+++ b/RXSpencerConfig.cmake.in
@@ -1,0 +1,11 @@
+# - Config file for the RXSpencer package
+
+@PACKAGE_INIT@
+
+set ( RXSPENCER_LIBRARIES rxspencer )
+set_and_check ( RXSPENCER_INCLUDE_DIRS @PACKAGE_RXSPENCER_INCLUDE_DIR@ )
+
+# Load targets
+if ( NOT TARGET rxspencer )
+  include ( @PACKAGE_CMAKE_CONFIG_DEST@/RXSpencerTargets.cmake )
+endif()

--- a/cmake/mkh.cmake
+++ b/cmake/mkh.cmake
@@ -1,0 +1,27 @@
+# Copyright (C) 2007-2012 LuaDist.
+# Created by Peter Kapec
+# Redistribution and use of this file is allowed according to the terms of the MIT license.
+# Please note that the package source code is licensed under its own license.
+
+# simplified reimplementation of included "mkh" script.
+function ( MKH INFILENAMES OUTFILENAME INC )
+  set ( MATCH " ==[ \t]" )
+  if ( INC )
+    set ( MATCH " =[ \t]" )
+  endif ( INC )
+  set ( TEXT "" )
+  foreach ( INFILENAME ${INFILENAMES} )
+  file ( READ "${INFILENAME}" TEXT_MORE )
+  set ( TEXT "${TEXT}${TEXT_MORE}" )
+  endforeach ( INFILENAME )
+  set ( TEXT "\n${TEXT}" )
+  string ( REGEX REPLACE "\n" "\nN" TEXT "${TEXT}" )
+  string ( REGEX REPLACE "\nN${MATCH}" "\nY" TEXT "${TEXT}" )
+  string ( REGEX REPLACE "\nN[^\n]*" "" TEXT "${TEXT}" )
+  string ( REGEX REPLACE "\nY([^\n]*)" "\\1\n" TEXT "${TEXT}" )
+  set ( TEXT "#ifdef __cplusplus\nextern \"C\" {\n#endif\n${TEXT}#ifdef __cplusplus\n}\n#endif\n" )
+  if ( INC )
+    set ( TEXT "#ifndef ${INC}\n#define ${INC}\n${TEXT}#endif\n" )
+  endif ( INC )
+  file ( WRITE "${OUTFILENAME}" "${TEXT}" )
+endfunction ( MKH )

--- a/librxspencer.def
+++ b/librxspencer.def
@@ -1,0 +1,5 @@
+EXPORTS
+regcomp
+regerror
+regexec
+regfree


### PR DESCRIPTION
This adds support for the CMake build system.
It is based on the CMake project files created for https://github.com/LuaDist/regex,
but modernized to also support CMake targets.